### PR TITLE
Remove leftover gitignore temp entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,5 +175,3 @@ dist
 
 # Wrangler generated types
 worker-configuration.d.ts
-
-temp


### PR DESCRIPTION
## Summary
- remove trailing `temp` line from `.gitignore`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f94cb2158832d947b835c6c5a98be