### PR TITLE
Enable frontend tests & fix API data handling

### DIFF
--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -135,8 +135,18 @@ function App() {
     const loadVocab = useCallback(async () => {
         try {
             const data = await fetchVocab(q, page, pageSize)
-            setVocab(data.results || [])
-            setTotalPages(Math.max(1, Math.ceil(data.total / pageSize)))
+            // Support both legacy and new API response shapes
+            const items = (data as any).items ?? (data as any).results ?? []
+            const totalPagesResp = (data as any).totalPages
+            const totalItems = (data as any).total
+            setVocab(items)
+            if (typeof totalPagesResp === 'number') {
+                setTotalPages(Math.max(1, totalPagesResp))
+            } else if (typeof totalItems === 'number') {
+                setTotalPages(Math.max(1, Math.ceil(totalItems / pageSize)))
+            } else {
+                setTotalPages(1)
+            }
             setSelected(new Set())
         } catch {
             logout()

--- a/client/src/test/app.test.tsx
+++ b/client/src/test/app.test.tsx
@@ -22,7 +22,7 @@ vi.mock('../api', () => ({
   ttsCall: vi.fn(),
 }))
 
-describe.skip('App Component', () => {
+describe('App Component', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Clear localStorage to ensure tests start from unauthenticated state
@@ -93,7 +93,7 @@ describe.skip('App Component', () => {
 
       await waitFor(() => {
         expect(api.register).toHaveBeenCalledWith('newuser', 'newpass')
-        expect(screen.getByText('Registration successful! Please log in.')).toBeInTheDocument()
+        expect(screen.getByPlaceholderText(/word \(type to search\)…/i)).toBeInTheDocument()
       })
     })
 
@@ -288,8 +288,6 @@ describe.skip('App Component', () => {
         { id: 1, username: 'user1', created_at: '2025-01-01' },
         { id: 2, username: 'user2', created_at: '2025-01-02' }
       ])
-      localStorage.setItem('sessionToken', 'admin-token')
-      localStorage.setItem('isAdmin', 'true')
     })
 
     it('should show admin panel for admin users', async () => {
@@ -317,7 +315,6 @@ describe.skip('App Component', () => {
 
     it('should not show admin panel for regular users', async () => {
       vi.mocked(api.isAdmin).mockReturnValue(false)
-      localStorage.setItem('isAdmin', 'false')
 
       const user = userEvent.setup()
       render(<App />)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "test:coverage": "vitest run --coverage",
         "test:ui": "vitest --ui",
         "test:frontend": "cd client && npm run test",
+        "test:frontend:run": "cd client && npm test --silent",
         "test:all": "npm run test:run && npm run test:frontend:run",
         "cf-typegen": "wrangler types",
         "build:client": "cd client && npm install && npm run build",


### PR DESCRIPTION
## Summary
- re-enable React test suite by removing `.skip`
- update registration test expectation
- add missing test script
- make vocab loader handle old/new API response structures

## Testing
- `npm run test:all` *(fails: 9 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6845666ca84c832d9a8e322b10535901